### PR TITLE
Move python wrapper implementation into a .cc file

### DIFF
--- a/PythonWrapper/BuildFile.xml
+++ b/PythonWrapper/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="boost"/>
-<use name="rootcintex"/>
-<use name="rootrflx"/>
+<use name="rootcore"/>
 <use name="roofitcore"/>
 <use name="FWCore/PythonParameterSet"/>
 <use name="ZZMatrixElement/MEMCalculators"/>

--- a/PythonWrapper/interface/MEMCalculatorsWrapper.h
+++ b/PythonWrapper/interface/MEMCalculatorsWrapper.h
@@ -1,19 +1,13 @@
-#include "ZZMatrixElement/MEMCalculators/interface/MEMCalculators.h"
-#include "ZZMatrixElement/MELA/src/computeAngles.h"
-
+#include <TLorentzVector.h>
+#include <vector>
+struct MEMs;
 
 class MEMCalculatorsWrapper 
 {
  public:
-  MEMCalculatorsWrapper(double collisionEnergy = 8, double sKD_mass = 125.6) {
-    mem_ = new MEMs(collisionEnergy,sKD_mass);
-  }
+  MEMCalculatorsWrapper(double collisionEnergy = 8, double sKD_mass = 125.6) ;
 
-
-  ~MEMCalculatorsWrapper() {
-    if(mem_ !=0) delete mem_;
-  }
-
+  ~MEMCalculatorsWrapper() ;
 
   struct Angles {
     float costhetastar,costheta1,costheta2,phi,phistar1;
@@ -21,118 +15,26 @@ class MEMCalculatorsWrapper
   Angles computeAngles(TLorentzVector Z1_lept1, int Z1_lept1Id,
 		   TLorentzVector Z1_lept2, int Z1_lept2Id,
 		   TLorentzVector Z2_lept1, int Z2_lept1Id,
-		   TLorentzVector Z2_lept2, int Z2_lept2Id) 
-  {
-    Angles ret;
-    mela::computeAngles(Z1_lept1,Z1_lept1Id,
-                        Z1_lept2,Z1_lept2Id,
-                        Z2_lept1,Z2_lept1Id,
-                        Z2_lept2,Z2_lept2Id,
-                    ret.costhetastar,ret.costheta1,ret.costheta2,ret.phi,ret.phistar1);
-    return ret;
-  }
+		   TLorentzVector Z2_lept2, int Z2_lept2Id) ;
 
   void  computeAll(TLorentzVector Z1_lept1, int Z1_lept1Id,
 		   TLorentzVector Z1_lept2, int Z1_lept2Id,
 		   TLorentzVector Z2_lept1, int Z2_lept1Id,
-		   TLorentzVector Z2_lept2, int Z2_lept2Id) {
+		   TLorentzVector Z2_lept2, int Z2_lept2Id) ;
 
-    std::vector<TLorentzVector> ps;
-    ps.push_back(Z1_lept1);
-    ps.push_back(Z1_lept2);
-    ps.push_back(Z2_lept1);
-    ps.push_back(Z2_lept2);
-
-    if ( Z2_lept1Id == Z2_lept2Id)
-      Z2_lept2Id=-Z2_lept2Id;
-
-
-    std::vector<int> id;
-    id.push_back(Z1_lept1Id);
-    id.push_back(Z1_lept2Id);
-    id.push_back(Z2_lept1Id);
-    id.push_back(Z2_lept2Id);
-
-    mem_->computeMEs(ps,id);
-
-    //Now the SuperKD part
-    pm4l_sig_=0.0;
-    pm4l_bkg_=0.0;
-    mem_->computePm4l(ps,id,kNone,pm4l_sig_,pm4l_bkg_);
-
-
-
-  }
-
-
-  float getKD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_qqZZ;
-    mem_->computeKD(kSMHiggs, kJHUGen, kqqZZ, kMCFM, &MEMs::probRatio, KD, ME_ggHiggs, ME_qqZZ);
-    return KD;
-  }
-
-  float getSuperKD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_qqZZ;
-    mem_->computeKD(kSMHiggs, kJHUGen, kqqZZ, kMCFM, &MEMs::probRatio, KD, ME_ggHiggs, ME_qqZZ);
-    return pm4l_sig_/(pm4l_sig_+pm4l_bkg_*(1./KD-1));
-  }
-
-  float getGG0KD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_gg0Minus;
-    mem_->computeKD(kSMHiggs, kJHUGen, k0minus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_gg0Minus);
-    return KD;
-  }
-
-  float getGG0HKD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_gg0hPlus;
-    mem_->computeKD(kSMHiggs, kJHUGen, k0hplus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_gg0hPlus);
-    return KD;
-  }
-  float getQQ1MinusKD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_qq1Minus;
-    mem_->computeKD(kSMHiggs, kJHUGen, k1minus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_qq1Minus);
-    return KD;
-  }
-
-  float getQQ1PlusKD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_qq2Plus;
-    mem_->computeKD(kSMHiggs, kJHUGen, k1plus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_qq2Plus);
-    return KD;
-  }
-  float getGG2PlusKD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_gg2Plus;
-    mem_->computeKD(kSMHiggs, kJHUGen, k2mplus_gg, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_gg2Plus);
-    return KD;
-  }
-  float getQQ2PlusKD() {
-    using namespace MEMNames;
-    double KD,ME_ggHiggs,ME_qq2Plus;
-    mem_->computeKD(kSMHiggs, kJHUGen, k2mplus_qqbar, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_qq2Plus);
-    return KD;
-  }
-
-
-
-  float getInterferenceWeight() {
-    return mem_->getMELAWeight();
-  }
-
-
-
+  float getKD() ;
+  float getSuperKD() ;
+  float getGG0KD() ;
+  float getGG0HKD() ;
+  float getQQ1MinusKD() ;
+  float getQQ1PlusKD() ;
+  float getGG2PlusKD() ;
+  float getQQ2PlusKD() ;
+  float getInterferenceWeight() ;
 
  private:
 
   MEMs * mem_;
   double pm4l_sig_;
   double pm4l_bkg_;
-
-
-
 };

--- a/PythonWrapper/src/MEMCalculatorsWrapper.cc
+++ b/PythonWrapper/src/MEMCalculatorsWrapper.cc
@@ -1,0 +1,134 @@
+#include "ZZMatrixElement/PythonWrapper/interface/MEMCalculatorsWrapper.h"
+
+#include "ZZMatrixElement/MEMCalculators/interface/MEMCalculators.h"
+#include "ZZMatrixElement/MELA/src/computeAngles.h"
+
+
+MEMCalculatorsWrapper::MEMCalculatorsWrapper(double collisionEnergy, double sKD_mass) {
+    mem_ = new MEMs(collisionEnergy,sKD_mass);
+}
+
+MEMCalculatorsWrapper::~MEMCalculatorsWrapper() {
+    if(mem_ !=0) delete mem_;
+}
+
+MEMCalculatorsWrapper::Angles 
+MEMCalculatorsWrapper::computeAngles(TLorentzVector Z1_lept1, int Z1_lept1Id,
+		   TLorentzVector Z1_lept2, int Z1_lept2Id,
+		   TLorentzVector Z2_lept1, int Z2_lept1Id,
+		   TLorentzVector Z2_lept2, int Z2_lept2Id) {
+    Angles ret;
+    mela::computeAngles(Z1_lept1,Z1_lept1Id,
+                        Z1_lept2,Z1_lept2Id,
+                        Z2_lept1,Z2_lept1Id,
+                        Z2_lept2,Z2_lept2Id,
+                    ret.costhetastar,ret.costheta1,ret.costheta2,ret.phi,ret.phistar1);
+    return ret;
+  }
+
+
+void  
+MEMCalculatorsWrapper::computeAll(TLorentzVector Z1_lept1, int Z1_lept1Id,
+		   TLorentzVector Z1_lept2, int Z1_lept2Id,
+		   TLorentzVector Z2_lept1, int Z2_lept1Id,
+		   TLorentzVector Z2_lept2, int Z2_lept2Id) {
+
+    std::vector<TLorentzVector> ps;
+    ps.push_back(Z1_lept1);
+    ps.push_back(Z1_lept2);
+    ps.push_back(Z2_lept1);
+    ps.push_back(Z2_lept2);
+
+    if ( Z2_lept1Id == Z2_lept2Id)
+      Z2_lept2Id=-Z2_lept2Id;
+
+
+    std::vector<int> id;
+    id.push_back(Z1_lept1Id);
+    id.push_back(Z1_lept2Id);
+    id.push_back(Z2_lept1Id);
+    id.push_back(Z2_lept2Id);
+
+    mem_->computeMEs(ps,id);
+
+    //Now the SuperKD part
+    pm4l_sig_=0.0;
+    pm4l_bkg_=0.0;
+    mem_->computePm4l(ps,id,kNone,pm4l_sig_,pm4l_bkg_);
+}
+
+
+float
+MEMCalculatorsWrapper:: getKD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_qqZZ;
+    mem_->computeKD(kSMHiggs, kJHUGen, kqqZZ, kMCFM, &MEMs::probRatio, KD, ME_ggHiggs, ME_qqZZ);
+    return KD;
+}
+
+float
+MEMCalculatorsWrapper:: getSuperKD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_qqZZ;
+    mem_->computeKD(kSMHiggs, kJHUGen, kqqZZ, kMCFM, &MEMs::probRatio, KD, ME_ggHiggs, ME_qqZZ);
+    return pm4l_sig_/(pm4l_sig_+pm4l_bkg_*(1./KD-1));
+}
+
+float
+MEMCalculatorsWrapper:: getGG0KD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_gg0Minus;
+    mem_->computeKD(kSMHiggs, kJHUGen, k0minus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_gg0Minus);
+    return KD;
+}
+
+float
+MEMCalculatorsWrapper:: getGG0HKD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_gg0hPlus;
+    mem_->computeKD(kSMHiggs, kJHUGen, k0hplus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_gg0hPlus);
+    return KD;
+}
+
+float
+MEMCalculatorsWrapper:: getQQ1MinusKD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_qq1Minus;
+    mem_->computeKD(kSMHiggs, kJHUGen, k1minus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_qq1Minus);
+    return KD;
+}
+
+float
+MEMCalculatorsWrapper:: getQQ1PlusKD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_qq2Plus;
+    mem_->computeKD(kSMHiggs, kJHUGen, k1plus, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_qq2Plus);
+    return KD;
+}
+
+float
+MEMCalculatorsWrapper:: getGG2PlusKD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_gg2Plus;
+    mem_->computeKD(kSMHiggs, kJHUGen, k2mplus_gg, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_gg2Plus);
+    return KD;
+}
+
+float
+MEMCalculatorsWrapper:: getQQ2PlusKD() {
+    using namespace MEMNames;
+    double KD,ME_ggHiggs,ME_qq2Plus;
+    mem_->computeKD(kSMHiggs, kJHUGen, k2mplus_qqbar, kJHUGen, &MEMs::probRatio, KD, ME_ggHiggs, ME_qq2Plus);
+    return KD;
+}
+
+
+
+float
+MEMCalculatorsWrapper:: getInterferenceWeight() {
+    return mem_->getMELAWeight();
+}
+
+
+
+

--- a/PythonWrapper/src/classes.h
+++ b/PythonWrapper/src/classes.h
@@ -1,4 +1,3 @@
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "ZZMatrixElement/PythonWrapper/interface/MEMCalculatorsWrapper.h"
 
 namespace {


### PR DESCRIPTION
Move python wrapper implementation into a .cc file, leaving the header clean to make root6/cling happy.
Tested in CMSSW_7_4_3 (ROOT 6.02); it should be backwards compatible also with 72X, though i didn't test it there.
Without the fix, the code compiles in 74X but attempts to instantiate the wrapper from PyROOT or CLING fail.