### PR TITLE
Python wrapper updates and cleanup

### DIFF
--- a/PythonWrapper/interface/MEMCalculatorsWrapper.h
+++ b/PythonWrapper/interface/MEMCalculatorsWrapper.h
@@ -1,5 +1,7 @@
 #include <TLorentzVector.h>
 #include <vector>
+#include <string>
+#include "DataFormats/Math/interface/LorentzVector.h"
 struct MEMs;
 
 class MEMCalculatorsWrapper 
@@ -16,11 +18,24 @@ class MEMCalculatorsWrapper
 		   TLorentzVector Z1_lept2, int Z1_lept2Id,
 		   TLorentzVector Z2_lept1, int Z2_lept1Id,
 		   TLorentzVector Z2_lept2, int Z2_lept2Id) ;
+  Angles computeAngles(const math::XYZTLorentzVector & Z1_lept1, int Z1_lept1Id,
+		   const math::XYZTLorentzVector & Z1_lept2, int Z1_lept2Id,
+		   const math::XYZTLorentzVector & Z2_lept1, int Z2_lept1Id,
+		   const math::XYZTLorentzVector & Z2_lept2, int Z2_lept2Id) ;
+
 
   void  computeAll(TLorentzVector Z1_lept1, int Z1_lept1Id,
 		   TLorentzVector Z1_lept2, int Z1_lept2Id,
 		   TLorentzVector Z2_lept1, int Z2_lept1Id,
 		   TLorentzVector Z2_lept2, int Z2_lept2Id) ;
+
+  std::vector<std::pair<std::string,float> > computeNew(
+              const math::XYZTLorentzVector & Z1_lept1, int Z1_lept1Id,
+              const math::XYZTLorentzVector & Z1_lept2, int Z1_lept2Id,
+              const math::XYZTLorentzVector & Z2_lept1, int Z2_lept1Id,
+              const math::XYZTLorentzVector & Z2_lept2, int Z2_lept2Id,
+              const std::vector<math::XYZTLorentzVector> & jetP4s) ;
+
 
   float getKD() ;
   float getSuperKD() ;

--- a/PythonWrapper/src/MEMCalculatorsWrapper.cc
+++ b/PythonWrapper/src/MEMCalculatorsWrapper.cc
@@ -26,6 +26,17 @@ MEMCalculatorsWrapper::computeAngles(TLorentzVector Z1_lept1, int Z1_lept1Id,
     return ret;
   }
 
+MEMCalculatorsWrapper::Angles 
+MEMCalculatorsWrapper::computeAngles(const math::XYZTLorentzVector & Z1_lept1, int Z1_lept1Id,
+		   const math::XYZTLorentzVector & Z1_lept2, int Z1_lept2Id,
+		   const math::XYZTLorentzVector & Z2_lept1, int Z2_lept1Id,
+		   const math::XYZTLorentzVector & Z2_lept2, int Z2_lept2Id) {
+    return computeAngles(TLorentzVector(Z1_lept1.Px(),Z1_lept1.Py(),Z1_lept1.Pz(),Z1_lept1.E()), Z1_lept1Id,
+                         TLorentzVector(Z1_lept2.Px(),Z1_lept2.Py(),Z1_lept2.Pz(),Z1_lept2.E()), Z1_lept2Id,
+                         TLorentzVector(Z2_lept1.Px(),Z2_lept1.Py(),Z2_lept1.Pz(),Z2_lept1.E()), Z2_lept1Id,
+                         TLorentzVector(Z2_lept2.Px(),Z2_lept2.Py(),Z2_lept2.Pz(),Z2_lept2.E()), Z2_lept2Id);
+  }
+
 
 void  
 MEMCalculatorsWrapper::computeAll(TLorentzVector Z1_lept1, int Z1_lept1Id,
@@ -55,6 +66,65 @@ MEMCalculatorsWrapper::computeAll(TLorentzVector Z1_lept1, int Z1_lept1Id,
     pm4l_sig_=0.0;
     pm4l_bkg_=0.0;
     mem_->computePm4l(ps,id,kNone,pm4l_sig_,pm4l_bkg_);
+}
+
+std::vector<std::pair<std::string,float>>  
+MEMCalculatorsWrapper::computeNew(
+        const math::XYZTLorentzVector & Z1_lept1, int Z1_lept1Id,
+        const math::XYZTLorentzVector & Z1_lept2, int Z1_lept2Id,
+        const math::XYZTLorentzVector & Z2_lept1, int Z2_lept1Id,
+        const math::XYZTLorentzVector & Z2_lept2, int Z2_lept2Id,
+        const std::vector<math::XYZTLorentzVector> & jets)
+{
+    std::vector<TLorentzVector> partP;
+    partP.emplace_back(Z1_lept1.Px(),Z1_lept1.Py(),Z1_lept1.Pz(),Z1_lept1.E());
+    partP.emplace_back(Z1_lept2.Px(),Z1_lept2.Py(),Z1_lept2.Pz(),Z1_lept2.E());
+    partP.emplace_back(Z2_lept1.Px(),Z2_lept1.Py(),Z2_lept1.Pz(),Z2_lept1.E());
+    partP.emplace_back(Z2_lept2.Px(),Z2_lept2.Py(),Z2_lept2.Pz(),Z2_lept2.E());
+
+    if (Z2_lept1Id == Z2_lept2Id) Z2_lept2Id = -Z2_lept2Id;
+    std::vector<int> partId;
+    partId.push_back(Z1_lept1Id);
+    partId.push_back(Z1_lept2Id);
+    partId.push_back(Z2_lept1Id);
+    partId.push_back(Z2_lept2Id);
+
+    double p0plus_VAJHU, bkg_VAMCFM, p0plus_m4l, bkg_m4l;
+    double p0minus_VAJHU, Dgg10_VAMCFM;
+
+    mem_->computeME(MEMNames::kSMHiggs, MEMNames::kJHUGen, partP, partId, p0plus_VAJHU); // Calculation of SM gg->H->4l JHUGen ME
+    mem_->computeME(MEMNames::k0minus, MEMNames::kJHUGen, partP, partId, p0minus_VAJHU); // Calculation of PS (0-, fa3=1) gg->H->4l JHUGen ME 
+    mem_->computeME(MEMNames::kggHZZ_10, MEMNames::kMCFM, partP, partId, Dgg10_VAMCFM); // Direct calculation of Dgg (D^kin for off-shell) from MCFM MEs
+    mem_->computeME(MEMNames::kqqZZ, MEMNames::kMCFM, partP, partId, bkg_VAMCFM); // qq->4l background calculation from MCFM
+    mem_->computePm4l(partP,partId, MEMNames::kNone, p0plus_m4l, bkg_m4l); // m4l probabilities for signal and background, nominal resolution
+
+    double D_bkg_kin = p0plus_VAJHU / ( p0plus_VAJHU + bkg_VAMCFM ); // D^kin_bkg
+    double D_bkg = p0plus_VAJHU * p0plus_m4l / ( p0plus_VAJHU * p0plus_m4l + bkg_VAMCFM * bkg_m4l ); // D^kin including superMELA
+    double D_g4 = p0plus_VAJHU / ( p0plus_VAJHU + p0minus_VAJHU ); // D_0-
+    std::vector<std::pair<std::string,float>> ret;
+    ret.emplace_back("D_bkg^kin",D_bkg_kin);
+    ret.emplace_back("D_bkg",D_bkg);
+    ret.emplace_back("D_gg",Dgg10_VAMCFM);
+    ret.emplace_back("D_0-", D_g4);
+
+    if (jets.size() >= 2) {
+        std::vector<TLorentzVector> partPprod(partP);
+        std::vector<int>            partIdprod(partId);
+        for (const auto &p4 : jets) {
+            partPprod.emplace_back(p4.Px(), p4.Py(), p4.Pz(), p4.E());
+            partIdprod.push_back(0);
+            if (partPprod.size() == 6) break;
+        }
+        double phjj_VAJHU, pvbf_VAJHU;
+        mem_->computeME(MEMNames::kJJ_SMHiggs_GG, MEMNames::kJHUGen,  partPprod, partIdprod, phjj_VAJHU); // SM gg->H+2j
+        mem_->computeME(MEMNames::kJJ_SMHiggs_VBF, MEMNames::kJHUGen, partPprod, partIdprod, pvbf_VAJHU);  // SM VBF->H
+        double Djet_VAJHU = pvbf_VAJHU / ( pvbf_VAJHU + phjj_VAJHU ); // D^VBF_HJJ
+        ret.emplace_back("D_HJJ^VBF", Djet_VAJHU);
+    } else {
+        ret.emplace_back("D_HJJ^VBF", -1.0);
+    }
+
+    return ret;
 }
 
 


### PR DESCRIPTION
- allow calling methods using the CMSSW LorentzVectors
  (older interface kept for backwards compatibility)
- update the KDs to what's currently in the Sync twiki
  https://twiki.cern.ch/twiki/bin/view/CMS/HiggsZZ4l2015?rev=70
  (plus fix float -> double when passing by reference)