### PR TITLE
fix mela path for compatibility with crab

### DIFF
--- a/MELA/src/Mela.cc
+++ b/MELA/src/Mela.cc
@@ -64,7 +64,9 @@ Mela::Mela(
   if (myVerbosity_>=TVar::DEBUG) cout << "Create symlinks to the required files if these are not already present:" << endl;
 
 #ifdef _melapkgpathstr_
-  const string MELAPKGPATH = _melapkgpathstr_;
+  //const string MELAPKGPATH = _melapkgpathstr_;
+  string MELAPKGPATH = std::getenv( "CMSSW_BASE" );
+  MELAPKGPATH+="/src/ZZMatrixElement/MELA/";
   if (myVerbosity_>=TVar::DEBUG)  cout << "\t- MELA package path: " << MELAPKGPATH << endl;
 #else
   cout << "MELA package path is undefined! Please modify the makefle or the makefile-equivalent!" << endl;
@@ -2000,7 +2002,9 @@ MelaPConstant* Mela::getPConstantHandle(
 
   if (myVerbosity_>=TVar::DEBUG) cout << "Mela::getPConstantHandle: relpath and spline name: " << relpath << ", " << spname << endl;
 #ifdef _melapkgpathstr_
-  const string MELAPKGPATH = _melapkgpathstr_;
+  //const string MELAPKGPATH = _melapkgpathstr_;
+  string MELAPKGPATH = std::getenv( "CMSSW_BASE" );
+  MELAPKGPATH+="/src/ZZMatrixElement/MELA/";
 #else
   cout << "Mela::getPConstantHandle: MELA package path is undefined! Please modify the makefle or the makefile-equivalent!" << endl;
   assert(0);

--- a/MELA/src/SuperMELA.cc
+++ b/MELA/src/SuperMELA.cc
@@ -496,7 +496,9 @@ void SuperMELA::calc_mZZ_range(const double mHVal, double& low_M, double& high_M
   //high_M=sqrts_*1000.;
 
 #ifdef _melapkgpathstr_
-  const string MELAPKGPATH = _melapkgpathstr_;
+  //const string MELAPKGPATH = _melapkgpathstr_;
+  string MELAPKGPATH = std::getenv( "CMSSW_BASE" );
+  MELAPKGPATH+="/src/ZZMatrixElement/MELA/";
 #else
   cout << "SuperMELA::calc_mZZ_range: MELA package path is undefined! Please modify the makefle or the makefile-equivalent!" << endl;
   assert(0);


### PR DESCRIPTION
When using the package with crab, these lines cause failures because they are hard linked to the directory where compilation occurred. Changing it to this allows the package to work with crab.